### PR TITLE
Add voice controls and progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# Aneto16
-Hassio Docker Aneto 16
+# Libro a Audio
+
+Aplicación web sencilla para convertir libros en formato **TXT** o **DOCX** en un archivo de audio **MP3**. Utiliza [Flask](https://flask.palletsprojects.com/) para la interfaz y [edge-tts](https://pypi.org/project/edge-tts/) para generar voces con entonación natural.
+
+## Requisitos
+- Python 3.10 o superior
+
+## Instalación
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+Necesitas tener instalado **ffmpeg** en tu sistema para que `pydub` pueda combinar los fragmentos de audio.
+
+## Uso
+```bash
+python app.py
+```
+Luego abre `http://localhost:5000` en tu navegador y:
+1. Sube un archivo `.txt` o `.docx`.
+2. Elige voz **femenina** o **masculina** y la velocidad de lectura.
+3. Indica la carpeta donde se guardará el MP3.
+4. Presiona **Procesar** y observa la barra de progreso con el tiempo estimado.
+
+El libro completo se guarda como un único archivo MP3 con el mismo nombre del archivo de entrada en la carpeta elegida.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,90 @@
+import os
+import asyncio
+from flask import Flask, request, render_template, redirect, url_for
+from docx import Document
+import edge_tts
+from pydub import AudioSegment
+
+app = Flask(__name__)
+
+def read_txt(path: str) -> str:
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+def read_docx(path: str) -> str:
+    doc = Document(path)
+    return "\n".join(par.text for par in doc.paragraphs)
+
+CHUNK_SIZE = 3000  # characters
+CHUNK_DELAY = 1    # seconds
+
+async def synthesize(
+    text: str,
+    out_path: str,
+    voice: str = "es-ES-SergioNeural",
+    rate: str = "0%",
+    style: str = "newscast-casual",
+):
+    chunks = [text[i : i + CHUNK_SIZE] for i in range(0, len(text), CHUNK_SIZE)]
+    temp_files = []
+    for idx, chunk in enumerate(chunks):
+        temp_file = f"temp_{idx}.mp3"
+        communicate = edge_tts.Communicate(chunk, voice=voice, style=style, rate=rate)
+        await communicate.save(temp_file)
+        temp_files.append(temp_file)
+        await asyncio.sleep(CHUNK_DELAY)
+
+    audio = AudioSegment.empty()
+    for f in temp_files:
+        audio += AudioSegment.from_file(f)
+        os.remove(f)
+    audio.export(out_path, format="mp3")
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files['archivo']
+        output_dir = request.form.get('salida') or 'salidas'
+        os.makedirs(output_dir, exist_ok=True)
+        gender = request.form.get('voz', 'femenina')
+        speed = request.form.get('velocidad', '0')
+
+        voice_map = {
+            'femenina': 'es-ES-ElviraNeural',
+            'masculina': 'es-ES-SergioNeural',
+        }
+        rate_map = {
+            'lenta': '-20%',
+            'normal': '0%',
+            'rapida': '+20%',
+        }
+
+        temp_dir = 'tmp'
+        os.makedirs(temp_dir, exist_ok=True)
+        temp_path = os.path.join(temp_dir, file.filename)
+        file.save(temp_path)
+
+        if file.filename.endswith('.txt'):
+            text = read_txt(temp_path)
+        elif file.filename.endswith('.docx'):
+            text = read_docx(temp_path)
+        else:
+            return 'Formato no soportado', 400
+
+        base_name = os.path.splitext(file.filename)[0]
+        output_file = os.path.join(output_dir, f'{base_name}.mp3')
+        voice_id = voice_map.get(gender, 'es-ES-ElviraNeural')
+        rate_val = rate_map.get(speed, '0%')
+        asyncio.run(synthesize(text, output_file, voice=voice_id, rate=rate_val))
+
+        return redirect(url_for('exito', carpeta=output_dir))
+
+    return render_template('index.html')
+
+@app.route('/exito')
+def exito():
+    carpeta = request.args.get('carpeta')
+    return render_template('exito.html', carpeta=carpeta)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=2.3.2
+python-docx>=0.8.11
+edge-tts>=6.1.10
+pydub>=0.25.1

--- a/templates/exito.html
+++ b/templates/exito.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Libro procesado</title>
+</head>
+<body>
+    <h1>Proceso completado</h1>
+    <p>El archivo de audio se guardó en: {{ carpeta }}</p>
+    <a href="/">Procesar otro libro</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Convertir Libro a Audio</title>
+</head>
+<body>
+    <h1>Subir Libro</h1>
+    <form id="convertForm" method="POST" enctype="multipart/form-data">
+        <label>Archivo (TXT o DOCX):</label><br>
+        <input type="file" id="archivo" name="archivo" required><br><br>
+
+        <label>Voz:</label><br>
+        <label><input type="radio" name="voz" value="femenina" checked> Femenina</label>
+        <label><input type="radio" name="voz" value="masculina"> Masculina</label><br><br>
+
+        <label>Velocidad:</label><br>
+        <select name="velocidad">
+            <option value="normal" selected>Normal</option>
+            <option value="lenta">Lenta</option>
+            <option value="rapida">Rápida</option>
+        </select><br><br>
+
+        <label>Carpeta de salida:</label><br>
+        <input type="text" name="salida" placeholder="salidas"><br><br>
+        <button type="submit">Procesar</button>
+    </form>
+
+    <div id="progress" style="display:none;">
+        <p id="time"></p>
+        <progress id="bar" max="100" value="0" style="width:300px;"></progress>
+    </div>
+
+    <script>
+    const form = document.getElementById('convertForm');
+    form.addEventListener('submit', () => {
+        const file = document.getElementById('archivo').files[0];
+        if (!file) return;
+        const est = Math.max(5, Math.round(file.size / 1000 * 0.5));
+        document.getElementById('time').textContent = `Tiempo estimado: ${est} s`;
+        const progress = document.getElementById('progress');
+        const bar = document.getElementById('bar');
+        progress.style.display = 'block';
+        let elapsed = 0;
+        const interval = setInterval(() => {
+            elapsed++;
+            bar.value = Math.min(100, elapsed * 100 / est);
+            if (elapsed >= est) clearInterval(interval);
+        }, 1000);
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Allow choosing male or female voice and reading speed
- Split text into chunks with delays to avoid rate limits and merge into one MP3
- Show a progress bar with estimated time during conversion

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=2.3.2 (from versions: none))*


------
https://chatgpt.com/codex/tasks/task_e_6892f8ae28d88326a0d7eedb910ebdf5