### PR TITLE
Harden file upload handling and validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,54 +1,81 @@
 import os
 import asyncio
+from typing import Set
+
 from flask import Flask, request, render_template, redirect, url_for
+from werkzeug.utils import secure_filename
 from docx import Document
 import edge_tts
 
+
+ALLOWED_EXTENSIONS: Set[str] = {"txt", "docx"}
+MAX_FILE_SIZE_MB = 16
+
 app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = MAX_FILE_SIZE_MB * 1024 * 1024
+
+
+def allowed_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
 
 def read_txt(path: str) -> str:
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         return f.read()
+
 
 def read_docx(path: str) -> str:
     doc = Document(path)
     return "\n".join(par.text for par in doc.paragraphs)
 
-async def synthesize(text: str, out_path: str, voice: str = "es-ES-SergioNeural", style: str = "newscast-casual"):
+
+async def synthesize(
+    text: str,
+    out_path: str,
+    voice: str = "es-ES-SergioNeural",
+    style: str = "newscast-casual",
+):
     communicate = edge_tts.Communicate(text, voice=voice, style=style)
     await communicate.save(out_path)
 
-@app.route('/', methods=['GET', 'POST'])
+
+@app.route("/", methods=["GET", "POST"])
 def index():
-    if request.method == 'POST':
-        file = request.files['archivo']
-        output_dir = request.form.get('salida') or 'salidas'
+    if request.method == "POST":
+        file = request.files.get("archivo")
+        if file is None or file.filename == "" or not allowed_file(file.filename):
+            return "Formato no soportado", 400
+
+        output_dir = secure_filename(request.form.get("salida") or "salidas")
         os.makedirs(output_dir, exist_ok=True)
 
-        temp_dir = 'tmp'
+        temp_dir = "tmp"
         os.makedirs(temp_dir, exist_ok=True)
-        temp_path = os.path.join(temp_dir, file.filename)
+        filename = secure_filename(file.filename)
+        temp_path = os.path.join(temp_dir, filename)
         file.save(temp_path)
 
-        if file.filename.endswith('.txt'):
+        if filename.endswith(".txt"):
             text = read_txt(temp_path)
-        elif file.filename.endswith('.docx'):
+        else:  # filename is guaranteed to end with .txt or .docx
             text = read_docx(temp_path)
-        else:
-            return 'Formato no soportado', 400
 
-        base_name = os.path.splitext(file.filename)[0]
-        output_file = os.path.join(output_dir, f'{base_name}.mp3')
+        base_name = os.path.splitext(filename)[0]
+        output_file = os.path.join(output_dir, f"{base_name}.mp3")
         asyncio.run(synthesize(text, output_file))
 
-        return redirect(url_for('exito', carpeta=output_dir))
+        os.remove(temp_path)
 
-    return render_template('index.html')
+        return redirect(url_for("exito", carpeta=output_dir))
 
-@app.route('/exito')
+    return render_template("index.html")
+
+
+@app.route("/exito")
 def exito():
-    carpeta = request.args.get('carpeta')
-    return render_template('exito.html', carpeta=carpeta)
+    carpeta = request.args.get("carpeta")
+    return render_template("exito.html", carpeta=carpeta)
 
-if __name__ == '__main__':
-    app.run(debug=True)
+
+if __name__ == "__main__":
+    app.run()

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     <h1>Subir Libro</h1>
     <form method="POST" enctype="multipart/form-data">
         <label>Archivo (TXT o DOCX):</label><br>
-        <input type="file" name="archivo" required><br><br>
+        <input type="file" name="archivo" accept=".txt,.docx" required><br><br>
         <label>Carpeta de salida:</label><br>
         <input type="text" name="salida" placeholder="salidas"><br><br>
         <button type="submit">Procesar</button>


### PR DESCRIPTION
## Summary
- sanitize upload and output paths with `secure_filename`
- restrict uploads to txt or docx and enforce size limits
- clean up temporary files and whitelist client-side formats

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689af38cecf48326890499b877a2e73c