### PR TITLE
Add chapter splitting and voice style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# Aneto16
-Hassio Docker Aneto 16
+# Libro a Audio
+
+Aplicación web que convierte libros en formato **TXT**, **DOCX** o **DOC** en archivos de audio **MP3**. Utiliza [Flask](https://flask.palletsprojects.com/) para la interfaz y [edge-tts](https://pypi.org/project/edge-tts/) para generar voces con entonación natural.
+
+## Requisitos
+- Python 3.10 o superior
+
+## Instalación
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+Necesitas tener instalado **ffmpeg** en tu sistema para que `pydub` pueda combinar los fragmentos de audio. Para archivos `.doc` se usa [textract](https://textract.readthedocs.io/), que requiere utilidades como `antiword` en el sistema.
+
+## Uso
+```bash
+python app.py
+```
+Luego abre `http://localhost:5000` en tu navegador y:
+1. Sube un archivo `.txt`, `.docx` o `.doc`.
+2. Elige voz **femenina** o **masculina**, la **velocidad** y el **estilo** (neutral, narración o alegre).
+3. Indica la carpeta donde se guardarán los MP3.
+4. Presiona **Procesar** y observa la barra de progreso con el tiempo estimado.
+
+El libro se divide en capítulos y se genera un archivo MP3 por cada uno en la carpeta indicada.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ python app.py
 ```
 Luego abre `http://localhost:5000` en tu navegador y:
 1. Sube un archivo `.txt`, `.docx` o `.doc`.
-2. Elige voz **femenina** o **masculina**, la **velocidad** y el **estilo** (neutral, narración o alegre).
+2. Escoge el **idioma** (castellano o catalán), la **voz** (femenina o masculina) y la **velocidad** de lectura.
 3. Indica la carpeta donde se guardarán los MP3.
 4. Presiona **Procesar** y observa la barra de progreso con el tiempo estimado.
 
-El libro se divide en capítulos y se genera un archivo MP3 por cada uno en la carpeta indicada.
+El texto se divide en capítulos y cada uno se procesa en bloques de 200 líneas para evitar límites de peticiones. Se genera un archivo MP3 por capítulo en la carpeta indicada.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,126 @@
+import os
+import re
+import asyncio
+from flask import Flask, request, render_template, redirect, url_for
+from docx import Document
+import textract
+import edge_tts
+from pydub import AudioSegment
+
+app = Flask(__name__)
+
+def read_txt(path: str) -> str:
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+def read_docx(path: str) -> str:
+    doc = Document(path)
+    return "\n".join(par.text for par in doc.paragraphs)
+
+def read_doc(path: str) -> str:
+    return textract.process(path).decode('utf-8')
+
+def split_into_chapters(text: str) -> list[str]:
+    pattern = re.compile(r"(?im)^cap[ií]tulo\s+\d+.*$|^chapter\s+\d+.*$", re.MULTILINE)
+    matches = list(pattern.finditer(text))
+    if not matches:
+        return [text]
+    chapters = []
+    for i, match in enumerate(matches):
+        start = match.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        chapters.append(text[start:end].strip())
+    return chapters
+
+CHUNK_SIZE = 3000  # characters
+CHUNK_DELAY = 1    # seconds
+
+async def synthesize(
+    text: str,
+    out_path: str,
+    voice: str = "es-ES-SergioNeural",
+    rate: str = "0%",
+    style: str = "general",
+):
+    chunks = [text[i : i + CHUNK_SIZE] for i in range(0, len(text), CHUNK_SIZE)]
+    temp_files = []
+    for idx, chunk in enumerate(chunks):
+        temp_file = f"temp_{idx}.mp3"
+        style_arg = None if style == 'general' else style
+        communicate = edge_tts.Communicate(chunk, voice=voice, style=style_arg, rate=rate)
+        await communicate.save(temp_file)
+        temp_files.append(temp_file)
+        await asyncio.sleep(CHUNK_DELAY)
+
+    audio = AudioSegment.empty()
+    for f in temp_files:
+        audio += AudioSegment.from_file(f)
+        os.remove(f)
+    audio.export(out_path, format="mp3")
+
+async def synthesize_book(text: str, out_dir: str, base: str, voice: str, rate: str, style: str) -> list[str]:
+    chapters = split_into_chapters(text)
+    files = []
+    for idx, chap in enumerate(chapters, start=1):
+        out = os.path.join(out_dir, f"{base}_capitulo_{idx}.mp3")
+        await synthesize(chap, out, voice=voice, rate=rate, style=style)
+        files.append(os.path.basename(out))
+    return files
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files['archivo']
+        output_dir = request.form.get('salida') or 'salidas'
+        os.makedirs(output_dir, exist_ok=True)
+        gender = request.form.get('voz', 'femenina')
+        speed = request.form.get('velocidad', '0')
+        style_sel = request.form.get('estilo', 'general')
+
+        voice_map = {
+            'femenina': 'es-ES-ElviraNeural',
+            'masculina': 'es-ES-SergioNeural',
+        }
+        rate_map = {
+            'lenta': '-20%',
+            'normal': '0%',
+            'rapida': '+20%',
+        }
+        style_map = {
+            'general': 'general',
+            'narracion': 'narration-professional',
+            'alegre': 'cheerful',
+        }
+
+        temp_dir = 'tmp'
+        os.makedirs(temp_dir, exist_ok=True)
+        temp_path = os.path.join(temp_dir, file.filename)
+        file.save(temp_path)
+
+        if file.filename.endswith('.txt'):
+            text = read_txt(temp_path)
+        elif file.filename.endswith('.docx'):
+            text = read_docx(temp_path)
+        elif file.filename.endswith('.doc'):
+            text = read_doc(temp_path)
+        else:
+            return 'Formato no soportado', 400
+
+        base_name = os.path.splitext(file.filename)[0]
+        voice_id = voice_map.get(gender, 'es-ES-ElviraNeural')
+        rate_val = rate_map.get(speed, '0%')
+        style_val = style_map.get(style_sel, 'general')
+        files = asyncio.run(synthesize_book(text, output_dir, base_name, voice_id, rate_val, style_val))
+        return redirect(url_for('exito', carpeta=output_dir, archivos=','.join(files)))
+
+    return render_template('index.html')
+
+@app.route('/exito')
+def exito():
+    carpeta = request.args.get('carpeta')
+    archivos = request.args.get('archivos', '')
+    lista = archivos.split(',') if archivos else []
+    return render_template('exito.html', carpeta=carpeta, archivos=lista)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask>=2.3.2
+python-docx>=0.8.11
+edge-tts>=6.1.10
+pydub>=0.25.1
+textract>=1.6.5

--- a/templates/exito.html
+++ b/templates/exito.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Libro procesado</title>
+</head>
+<body>
+    <h1>Proceso completado</h1>
+    <p>Los archivos de audio se guardaron en: {{ carpeta }}</p>
+    <ul>
+    {% for a in archivos %}
+        <li>{{ a }}</li>
+    {% endfor %}
+    </ul>
+    <a href="/">Procesar otro libro</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,12 @@
         <label>Archivo (TXT, DOCX o DOC):</label><br>
         <input type="file" id="archivo" name="archivo" required><br><br>
 
+        <label>Idioma:</label><br>
+        <select name="idioma">
+            <option value="es" selected>Castellano</option>
+            <option value="ca">Catalán</option>
+        </select><br><br>
+
         <label>Voz:</label><br>
         <label><input type="radio" name="voz" value="femenina" checked> Femenina</label>
         <label><input type="radio" name="voz" value="masculina"> Masculina</label><br><br>
@@ -19,13 +25,6 @@
             <option value="normal" selected>Normal</option>
             <option value="lenta">Lenta</option>
             <option value="rapida">Rápida</option>
-        </select><br><br>
-
-        <label>Estilo de voz:</label><br>
-        <select name="estilo">
-            <option value="general" selected>Neutral</option>
-            <option value="narracion">Narración</option>
-            <option value="alegre">Alegre</option>
         </select><br><br>
 
         <label>Carpeta de salida:</label><br>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Convertir Libro a Audio</title>
+</head>
+<body>
+    <h1>Subir Libro</h1>
+    <form id="convertForm" method="POST" enctype="multipart/form-data">
+        <label>Archivo (TXT, DOCX o DOC):</label><br>
+        <input type="file" id="archivo" name="archivo" required><br><br>
+
+        <label>Voz:</label><br>
+        <label><input type="radio" name="voz" value="femenina" checked> Femenina</label>
+        <label><input type="radio" name="voz" value="masculina"> Masculina</label><br><br>
+
+        <label>Velocidad:</label><br>
+        <select name="velocidad">
+            <option value="normal" selected>Normal</option>
+            <option value="lenta">Lenta</option>
+            <option value="rapida">Rápida</option>
+        </select><br><br>
+
+        <label>Estilo de voz:</label><br>
+        <select name="estilo">
+            <option value="general" selected>Neutral</option>
+            <option value="narracion">Narración</option>
+            <option value="alegre">Alegre</option>
+        </select><br><br>
+
+        <label>Carpeta de salida:</label><br>
+        <input type="text" name="salida" placeholder="salidas"><br><br>
+        <button type="submit">Procesar</button>
+    </form>
+
+    <div id="progress" style="display:none;">
+        <p id="time"></p>
+        <progress id="bar" max="100" value="0" style="width:300px;"></progress>
+    </div>
+
+    <script>
+    const form = document.getElementById('convertForm');
+    form.addEventListener('submit', () => {
+        const file = document.getElementById('archivo').files[0];
+        if (!file) return;
+        const est = Math.max(5, Math.round(file.size / 1000 * 0.5));
+        document.getElementById('time').textContent = `Tiempo estimado: ${est} s`;
+        const progress = document.getElementById('progress');
+        const bar = document.getElementById('bar');
+        progress.style.display = 'block';
+        let elapsed = 0;
+        const interval = setInterval(() => {
+            elapsed++;
+            bar.value = Math.min(100, elapsed * 100 / est);
+            if (elapsed >= est) clearInterval(interval);
+        }, 1000);
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Generate a separate MP3 for each chapter with edge-tts and pacing delays
- Allow selecting neutral, narration or cheerful speaking styles alongside gender and speed
- List produced files on completion and document DOC support and requirements

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask>=2.3.2)*

------
https://chatgpt.com/codex/tasks/task_e_6892f8ae28d88326a0d7eedb910ebdf5